### PR TITLE
Add search term to HowLongToBeatEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ hltbService.search('Nioh').then(result => console.log(result));
     gameplayMain: 34.5,
     gameplayMainExtra: 61,
     gameplayCompletionist: 93.5,
-    similarity: 1
+    similarity: 1,
+    searchTerm: 'Nioh'
     },
     {
     id: '50419',
@@ -67,7 +68,8 @@ hltbService.search('Nioh').then(result => console.log(result));
     gameplayMain: 42,
     gameplayMainExtra: 84,
     gameplayCompletionist: 97,
-    similarity: 0.18
+    similarity: 0.18,
+    searchTerm: 'Nioh'
     },
     ...
 ]
@@ -95,7 +97,8 @@ The `search()` method will return a `Promise` with an `HowLongToBeatEntry`. If t
   gameplayMain: 34.5,
   gameplayMainExtra: 61,
   gameplayCompletionist: 93.5,
-  similarity: 1
+  similarity: 1,
+  searchTerm: 'Nioh'
 }
 ```
 

--- a/src/main/howlongtobeat.ts
+++ b/src/main/howlongtobeat.ts
@@ -84,7 +84,7 @@ export class HowLongToBeatParser {
 
     let liElements = $('.game_times li');
     const gameDescription = $(
-      '.in.back_primary.shadow_box p:first-child'
+      '.in.back_primary.shadow_box div.profile_info.large'
     ).text();
 
     let platforms = [];

--- a/src/main/howlongtobeat.ts
+++ b/src/main/howlongtobeat.ts
@@ -52,7 +52,8 @@ export class HowLongToBeatEntry {
     public readonly gameplayMain: number,
     public readonly gameplayMainExtra: number,
     public readonly gameplayCompletionist: number,
-    public readonly similarity: number
+    public readonly similarity: number,
+    public readonly searchTerm: string
   ) {
     this.playableOn = platforms;
   }
@@ -136,7 +137,8 @@ export class HowLongToBeatParser {
       gameplayMain,
       gameplayMainExtra,
       gameplayComplete,
-      1
+      1,
+      gameName
     );
   }
 
@@ -226,7 +228,8 @@ export class HowLongToBeatParser {
           main,
           mainExtra,
           complete,
-          HowLongToBeatParser.calcDistancePercentage(gameName, searchTerm)
+          HowLongToBeatParser.calcDistancePercentage(gameName, searchTerm),
+          searchTerm
         );
         results.push(entry);
       });

--- a/src/test/howlongtobeat.integration.test.ts
+++ b/src/test/howlongtobeat.integration.test.ts
@@ -14,6 +14,7 @@ describe('Integration-Testing HowLongToBeatService', () => {
         assert.isNotNull(entry);
         assert.strictEqual(entry.id, '2224');
         assert.strictEqual(entry.name, 'Dark Souls');
+        assert.strictEqual(entry.searchTerm, 'Dark Souls');
         assert.isString(entry.imageUrl);
         assert.isArray(entry.platforms);
         assert.strictEqual(entry.platforms.length, 4);

--- a/src/test/howlongtobeat.test.ts
+++ b/src/test/howlongtobeat.test.ts
@@ -32,6 +32,7 @@ describe('Testing HowLongToBeatParser', () => {
       let results = HowLongToBeatParser.parseSearch(html, 'Persona 4');
       assert.isTrue(results.length === 5);
       assert.strictEqual(results[0].name, 'Persona 4: Golden');
+      assert.strictEqual(results[0].searchTerm, 'Persona 4');
       assert.strictEqual(results[0].similarity, 0.53);
       assert.strictEqual(
         results[0].imageUrl,
@@ -56,6 +57,7 @@ describe('Testing HowLongToBeatParser', () => {
       let detail = HowLongToBeatParser.parseDetails(html, '3978');
       assert.isDefined(detail);
       assert.strictEqual(detail.name, 'God of War III');
+      assert.strictEqual(detail.searchTerm, 'God of War III');
       assert.strictEqual(detail.similarity, 1);
       assert.strictEqual(detail.playableOn.length, 3);
       assert.strictEqual(detail.platforms.length, 3);
@@ -74,6 +76,7 @@ describe('Testing HowLongToBeatParser', () => {
       const detail = HowLongToBeatParser.parseDetails(html, '9224');
       assert.isDefined(detail);
       assert.strictEqual(detail.name, 'Street Fighter');
+      assert.strictEqual(detail.searchTerm, 'Street Fighter');
       assert.strictEqual(detail.similarity, 1);
       //should be one, since 1 hours is the minimum
       assert.strictEqual(detail.gameplayMain, 1);
@@ -93,6 +96,7 @@ describe('Testing HowLongToBeatParser', () => {
       assert.strictEqual(search.length, 18);
       const streetFighter = search[0];
       assert.strictEqual(streetFighter.name, 'Street Fighter');
+      assert.strictEqual(streetFighter.searchTerm, 'Street Fighter');
       assert.strictEqual(streetFighter.gameplayMain, 1);
       assert.strictEqual(streetFighter.gameplayMainExtra, 1);
       assert.strictEqual(streetFighter.gameplayCompletionist, 3.5);
@@ -115,6 +119,7 @@ describe('Testing HowLongToBeatParser', () => {
       const detail = HowLongToBeatParser.parseDetails(html, '4216');
       assert.isDefined(detail);
       assert.strictEqual(detail.name, 'Guns of Icarus Online');
+      assert.strictEqual(detail.searchTerm, 'Guns of Icarus Online');
       assert.strictEqual(detail.similarity, 1);
       //should be one, since 1 hours is the minimum
       assert.strictEqual(detail.gameplayMain, 0);
@@ -133,6 +138,7 @@ describe('Testing HowLongToBeatParser', () => {
       assert.strictEqual(search.length, 18);
       const gtaV = search[2];
       assert.strictEqual(gtaV.name, 'Grand Theft Auto V');
+      assert.strictEqual(gtaV.searchTerm, 'Grand Theft Auto');
       assert.strictEqual(gtaV.gameplayMain, 31);
       assert.strictEqual(gtaV.gameplayMainExtra, 46.5);
       assert.strictEqual(gtaV.gameplayCompletionist, 78.5);
@@ -144,6 +150,10 @@ describe('Testing HowLongToBeatParser', () => {
       assert.strictEqual(
         gtaOnline.name,
         'Grand Theft Auto Online'
+      );
+      assert.strictEqual(
+        gtaOnline.searchTerm,
+        'Grand Theft Auto'
       );
       assert.strictEqual(gtaOnline.gameplayMain, 32.5);
       assert.strictEqual(gtaOnline.gameplayMainExtra, 28);


### PR DESCRIPTION
This pull request adds the original search term to the `HowLongToBeatEntry` class.  

**Use case**  
When searching for games, currently only the similarity is returned. Now the original search term is also included.

**Tests**  
I also updated the selector to fix one of the failing tests. 